### PR TITLE
Create all of the required resources and config

### DIFF
--- a/manifests/cluster-services/templates/vault.yaml
+++ b/manifests/cluster-services/templates/vault.yaml
@@ -15,6 +15,14 @@ spec:
           value: ""
         - name: server.ha.enabled
           value: "true"
+        - name: server.ha.config
+          value: |
+            seal "gcpckms" {
+               project     = "{{ .Values.spec.gcpProject }}"
+               region      = "global"
+               key_ring    = "vault-keyring"
+               crypto_key  = "vault-key"
+            }
         - name: server.ha.raft.enabled
           value: "true"
         - name: server.serviceAccount.annotations.iam\.gke\.io\/gcp-service-account

--- a/manifests/cluster-services/templates/vault.yaml
+++ b/manifests/cluster-services/templates/vault.yaml
@@ -17,6 +17,8 @@ spec:
           value: "true"
         - name: server.ha.raft.enabled
           value: "true"
+        - name: server.serviceAccount.annotations.iam\.gke\.io\/gcp-service-account
+          value: "vault-gcpkms@homelab-376317.iam.gserviceaccount.com"
   destination:
     server: {{ .Values.spec.destination.server }}
     namespace: vault

--- a/manifests/cluster-services/templates/vault.yaml
+++ b/manifests/cluster-services/templates/vault.yaml
@@ -18,7 +18,7 @@ spec:
         - name: server.ha.raft.enabled
           value: "true"
         - name: server.serviceAccount.annotations.iam\.gke\.io\/gcp-service-account
-          value: "vault-gcpkms@homelab-376317.iam.gserviceaccount.com"
+          value: vault-gcpkms@{{ .Values.spec.gcpProject }}.iam.gserviceaccount.com
   destination:
     server: {{ .Values.spec.destination.server }}
     namespace: vault

--- a/manifests/cluster-services/values.yaml
+++ b/manifests/cluster-services/values.yaml
@@ -1,4 +1,5 @@
 spec:
+  gcpProject: homelab-376317
   cluster:
     baseDomain: gke.wevans.io
   destination:


### PR DESCRIPTION
Problem
------
We need to be able to start the vault service without too much manual intervention. 


Solution
------
We should utilize the vault auto-unseal functionality with GCP KMS serving as the keystore for the unseal keys, rather than a manually generated keyshare.

Details
------
- [x] Create a GCP Service Account 
- [x] Allow the GCP Service Account to utilize a KMS key and keyring for unsealing
- [x] Enable Workload Identity in the GKE Cluster
- [x] Allow the Vault K8s Service Account to Bind to the GCP Service Account 
- [x] Configure Vault to utilize auto-unseal